### PR TITLE
Issue 3: Add API endpoint for NFC tags

### DIFF
--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -1,6 +1,4 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
 export default (req, res) => {
   res.statusCode = 200
-  res.json({ name: 'John Doe' })
+  res.json({ text: 'Hello world!' })
 }

--- a/pages/api/tags/[tId].js
+++ b/pages/api/tags/[tId].js
@@ -1,0 +1,8 @@
+export default (req, res) => {
+  const {
+    query: { tId },
+  } = req
+  res.end(
+    `Tag: ${tId}`
+    )
+};

--- a/pages/api/tags/index.js
+++ b/pages/api/tags/index.js
@@ -1,0 +1,5 @@
+export default (req, res) => {
+    res.statusCode = 200
+    res.json({ text: 'Here is all the tags' })
+  }
+  


### PR DESCRIPTION
## idea
When a NFC tag is triggered, an UI will open up with whatever function you want to do. For instance, call an API, send a slack message.

In my case, I want to:

1. Place a NFC tag near my bed
2. 'When'  this NFC tag is triggered, the UI will open the URL and make an API call (no authentication for now) to Toggl. If 'night' (8:00 pm to 4:00 am) it will 'start' a 'sleep timer.' If day, it will stop any timer.
3. 'After' this action is performed  I want  to have a Slack message with a daily  overview of my sleep.

## next:

1. Getting creative, what if I could also turn on/offf the lights of my bedroom? Or set a custom scene? Let's see!
2. Authentication (!!!)